### PR TITLE
Fix response to 'DELETE'

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,8 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson) => {
                 };
             case CREATE:
                 return { data: { ...params.data, id: json.id } };
+            case DELETE:
+                return { data: { id: null } };
             default:
                 return { data: json };
         }


### PR DESCRIPTION
When deleting a resource in the edit view, I am getting the following error in console:

> The response to 'DELETE' must be like { data: { id: 123, ... } }, but the received data does not have an 'id' key. The dataProvider is probably wrong for 'DELETE'