### PR TITLE
Replace Content-Range with count endpoint of strapi

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ export default (apiUrl, httpClient = fetchUtils.fetchJson, uploadFields = []) =>
         const { headers, json, total } = response;
         switch (type) {
 	    case GET_ONE:
-	        return { data: replaceRefObjectsWithIds(json) };
+	        return { data: json };
             case GET_LIST:
             case GET_MANY_REFERENCE:
                 return {


### PR DESCRIPTION
Replace Content-Range header with an additional request to the count route of strapi.

Adapt the readme to reflect these changes. This closes #22. 